### PR TITLE
Allow For Device ID Only

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,16 @@ Metrics/MethodLength:
     # is difficult to break up reasonably and keep it easy to understand
     - scrub_pii
 
+Metrics/CyclomaticComplexity:
+  IgnoredMethods:
+    # `record` is too complex mostly due to safety checks and not core logic
+    - record
+
+Metrics/PerceivedComplexity:
+  IgnoredMethods:
+    # `record` is too complex mostly due to safety checks and not core logic
+    - record
+
 Metrics/AbcSize:
   IgnoredMethods:
     - record

--- a/lib/path/reporting/analytics.rb
+++ b/lib/path/reporting/analytics.rb
@@ -162,9 +162,9 @@ module Path
         trigger: Trigger::INTERACTION,
         metadata: {}
       )
-        throw Error.new("No user hash provided when reporting analytics") if !user.is_a?(Hash) || !(user[:id] || user["id"])
-        throw Error.new("Invalid UserType #{user_type}") unless UserType.valid?(user_type)
-        throw Error.new("Invalid Trigger #{trigger}") unless Trigger.valid?(trigger)
+        raise Error, "No user hash provided when reporting analytics" if !user.is_a?(Hash) || !(user[:id] || user["id"] || user[:device_id] || user["device_id"])
+        raise Error, "Invalid UserType #{user_type}" unless UserType.valid?(user_type)
+        raise Error, "Invalid Trigger #{trigger}" unless Trigger.valid?(trigger)
 
         clients.map do |reporter, client|
           {

--- a/spec/analytics_spec.rb
+++ b/spec/analytics_spec.rb
@@ -116,5 +116,33 @@ RSpec.describe Path::Reporting::Analytics do
         )
       end
     end
+
+    context "given neither a user device id nor user id" do
+      specify do
+        expect do
+          recorder.record(product_code: "rspec", product_area: "recorder test", name: "test run", user: {})
+        end.to raise_error Path::Reporting::Error, "No user hash provided when reporting analytics"
+      end
+    end
+
+    context "given just a user device id" do
+      it "passes along all values them" do
+        expect(console_channel).to receive(:record).with(
+          trigger: "auto",
+          name: "RSPEC_RecorderTest_Test_run",
+          user: { 'device_id': 1 },
+          user_type: "rspec",
+          metadata: {}
+        )
+        recorder.record(
+          product_code: "rspec",
+          product_area: "recorder test",
+          name: "test run",
+          user: { 'device_id': 1 },
+          user_type: "rspec",
+          trigger: "auto"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Amplitude requires either a "Device ID" or id. This is expanding our existing code to allow for only specifying device id.

Test Plan:
bundle exec rspec