### PR TITLE
Don't Send User ID to Amplitude If Not Present

### DIFF
--- a/lib/path/reporting/analytics/amplitude.rb
+++ b/lib/path/reporting/analytics/amplitude.rb
@@ -86,11 +86,12 @@ module Path
           metadata[:system_name] = config.system_name
 
           event_props = {
-            user_id: (user[:id] || user["id"]).to_s,
             user_properties: scrub_pii(user),
             event_type: name,
             event_properties: scrub_pii(metadata)
           }
+          event_props[:user_id] = (user[:id] || user["id"]).to_s unless (user[:id] || user["id"]).nil?
+          event_props[:device_id] = (user[:device_id] || user["device_id"]).to_s unless (user[:device_id] || user["device_id"]).nil?
           API_METADATA_TO_ELEVATE.each do |key|
             event_props[key] = metadata[key] if metadata.key? key
           end

--- a/spec/analytics/reporters/amplitude_spec.rb
+++ b/spec/analytics/reporters/amplitude_spec.rb
@@ -61,5 +61,21 @@ RSpec.describe Path::Reporting::Analytics::Amplitude do
         user_type: "runner"
       )
     end
+
+    it "report event with device_id only to Amplitude using the API" do
+      expect(AmplitudeAPI::Event).to receive(:new).with({
+                                                          'event_properties': { 'system_name': "test", 'trigger': "test" },
+                                                          'event_type': "Test_event",
+                                                          'device_id': "1",
+                                                          'user_properties': { 'device_id': 1, 'user_type': "runner" }
+                                                        }).and_return(api_event)
+      expect(AmplitudeAPI).to receive(:track).with(api_event).and_return(response)
+      channel_instance.record(
+        trigger: "test",
+        name: "Test_event",
+        user: { 'device_id': 1 },
+        user_type: "runner"
+      )
+    end
   end
 end


### PR DESCRIPTION
Turns out Ampitude is very particular and doesn't like us sending the user_id property with an empty value. So if we don't have a user_id, we now don't send it to Amplitude at all.

Test Plan:
bundle exec rspec